### PR TITLE
Ability to suppress Trace logging

### DIFF
--- a/FarmHouseRedone/Logger.cs
+++ b/FarmHouseRedone/Logger.cs
@@ -10,10 +10,13 @@ namespace FarmHouseRedone
     public static class Logger
     {
         public static IMonitor monitor;
+        public static bool suppressTrace;
 
         public static void Log(string log, LogLevel level = LogLevel.Trace)
         {
             if (monitor == null)
+                return;
+            if (Logger.suppressTrace && (level == LogLevel.Trace))
                 return;
             monitor.Log(log, level);
         }

--- a/FarmHouseRedone/ModEntry.cs
+++ b/FarmHouseRedone/ModEntry.cs
@@ -11,11 +11,26 @@ using Netcode;
 
 namespace FarmHouseRedone
 {
+    class ModConfig
+    {
+        public bool suppressTraceLog { get; set; } = false;
+    }
+
     public class ModEntry : Mod
     {
+        private ModConfig Config;
+
         public override void Entry(IModHelper helper)
         {
+            this.Config = this.Helper.ReadConfig<ModConfig>();
+
+            Logger.suppressTrace = this.Config.suppressTraceLog;
             Logger.monitor = Monitor;
+            if (Logger.suppressTrace)
+            {
+                Logger.Log("WARNING: Trace Logging has been disabled from config.json!", LogLevel.Warn);
+            }
+
             FarmHouseStates.harmony = HarmonyInstance.Create("mabelsyrup.farmhouse");
             FarmHouseStates.spouseRooms = new Dictionary<string, int>();
             FarmHouseStates.reflector = helper.Reflection;


### PR DESCRIPTION
This mod, maybe due to its "beta" status, is VERY chatty.

Out of 15'000 lines of log, 14'000+ came from this mod.

This makes it VERY difficult to troubleshoot other mods.

So, I added a config.json knob to be able to temporarily disable Trace
logging from this mod. The knob defaults to "false", of course.

Examples:

```sh
# BEFORE adding the knob
% wc -l SMAPI-latest.txt
4758 SMAPI-latest.txt
% grep Redone SMAPI-latest.txt| wc -l
3193

# AFTER adding the knob and setting it to "true"
% wc -l SMAPI-latest.txt
1538 SMAPI-latest.txt

% grep Redone SMAPI-latest.txt| wc -l
8
```

And the above 2 have the same scenario: Open the game, load a save, wait until farmhouse is drawn, exit to desktop.

